### PR TITLE
Fix #1: Footer label not visible on Home and Game screens

### DIFF
--- a/frontend/src/components/iPadFrame.vue
+++ b/frontend/src/components/iPadFrame.vue
@@ -108,7 +108,7 @@ onUnmounted(() => {
   height: 100%;
   background: #0f172a;
   border-radius: 8px;
-  overflow: hidden;
+  overflow: auto;
   position: relative;
   /* Screen bezel reflection effect */
   box-shadow:


### PR DESCRIPTION
Root Cause:
The iPadFrame component's `.ipad-screen` element had `overflow: hidden` which clipped any content that extended beyond the viewport boundaries. The footer in HomeView.vue was being rendered but cut off by this overflow constraint.

Fix:
Changed `.ipad-screen` overflow from `hidden` to `auto`, allowing content to scroll if needed while still containing it within the iPad frame boundaries. This ensures the footer is always visible on both desktop (iPad frame) and tablet views.

Affected views:
- HomeView.vue (footer with "Ein digitaler Spielbegleiter...")
- All views wrapped by iPadFrame component

Tested on:
- Desktop browser (iPad frame visible)
- Tablet viewport (no frame, full screen)

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)