### PR TITLE
Fix #1: Footer label not visible on Home screen

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -106,8 +106,7 @@ onMounted(async () => {
 <style scoped>
 .home-view {
   @apply bg-slate-900;
-  height: 100vh;
-  height: 100dvh;
+  height: 100%;
   display: flex;
   flex-direction: column;
   overflow: hidden;


### PR DESCRIPTION
Root Cause:
The HomeView component used `height: 100vh` which made it taller than its parent container (the iPadFrame's screen area). Combined with `overflow: hidden` on the parent, the footer was rendered but clipped.

Fix:
Changed HomeView's height from `100vh` to `100%` so it respects the parent container's boundaries. The iPadFrame's `overflow: hidden` is preserved to prevent scrollbars on all screens.

The footer "Ein digitaler Spielbegleiter für analoge Spieleabende" is now visible on the Home screen on both desktop (iPad frame) and tablet views.

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)